### PR TITLE
docs: enrich README to match the @brmorillo/utils standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [5.0.1](https://github.com/brmorillo/global-locations/compare/v5.0.0...v5.0.1) (2026-06-18)
+
+
+### Bug Fixes
+
+* exclude sourcemaps from the published package ([4208c6a](https://github.com/brmorillo/global-locations/commit/4208c6af2c15b56b17110acd53703a06ec03a71c))
+
+
+### Documentation
+
+* enrich README to match the @brmorillo/utils standard ([5a24324](https://github.com/brmorillo/global-locations/commit/5a2432437ab39eedbecc412955902e60c20368ee))
+
 ## [5.0.0](https://github.com/brmorillo/global-locations/compare/v4.0.3...v5.0.0) (2026-06-17)
 
 

--- a/README.md
+++ b/README.md
@@ -8,67 +8,171 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-3178c6.svg)](https://www.typescriptlang.org/)
 [![License: LGPL-3.0](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
 
-Library for accessing global location data such as countries, states, and cities.
+> Countries, states and cities — one type-safe API, batteries (and data) included.
+
+A production-ready library for **global location data**. It bundles a complete dataset of countries → states → cities and exposes it behind a single, consistent, type-safe service. No network calls, no API keys — the data ships with the package and is queried in-memory.
+
+- 🌍 **Complete dataset** — countries, their states/provinces and cities, bundled in the package
+- 🎯 **Type-safe** — full TypeScript types, ships its own declarations
+- 📦 **Dual build** — CommonJS **and** ESM
+- 🧩 **Consistent API** — one static service, predictable single-object arguments
+- 🔌 **Offline** — no HTTP, no keys; everything resolves locally
+- 🧪 **Well tested** — 92 unit/integration tests, 100% coverage, validated via a real CJS+ESM consumer
 
 ## Installation
 
 ```bash
+bun add @brmorillo/global-locations
+# or
 npm install @brmorillo/global-locations
+# or
+pnpm add @brmorillo/global-locations
+# or
+yarn add @brmorillo/global-locations
 ```
 
-## Usage
+Requires **Node.js >= 18**.
+
+## Quick start
 
 ```typescript
-import { GlobalLocations } from '@brmorillo/global-locations';
+import { GlobalLocations, Countries } from '@brmorillo/global-locations';
 
-// Get all countries
+// via the facade…
 const countries = GlobalLocations.Countries.getAllCountries();
 
-// Get a specific country by ID
-const brazil = GlobalLocations.Countries.getCountryBy({
+// …or the class directly
+const brazil = Countries.getCountryBy({
   property: 'id',
   value: 'BR',
-  selectStates: true
+  selectStates: true,
 });
 
-// Get states of a country
-const brazilStates = GlobalLocations.Countries.getStatesByCountryId('BR');
-
-// Get cities of a state
-const saoPauloCities = GlobalLocations.Countries.getCitiesByStateId({
+const states = Countries.getStatesByCountryId('BR');          // State[]
+const cities = Countries.getCitiesByStateId({                 // string[]
   countryId: 'BR',
-  stateId: '35'
+  stateId: '35',
 });
+
+// search & filter
+Countries.searchCitiesByName('paulo');                        // [{ city, state, country }, …]
+Countries.getCountriesByContinent('South America');           // Country[]
+Countries.getCountriesByEconomicGroup('Mercosul');            // Country[]
 ```
+
+Both `require` (CJS) and `import` (ESM) are supported — the package exposes the
+right entry point for each via its `exports` map.
+
+## Data model
+
+The dataset is a tree of `Country → State → City`:
+
+```ts
+interface City    { id: number; stateId: number; name: string; extra?: object }
+interface State   { id: number; name: string; acronym: string; cities: City[] }
+interface Country {
+  id: string;            // ISO code, e.g. "BR"
+  name: string;          // "Brasil"
+  acronym: string;
+  capital: string;
+  coin: string;
+  coinCode: string;      // "BRL"
+  regionGroup: string;
+  economicGroups: string[];
+  continent: string;
+  ddi: string;           // international dialling code, e.g. "+55"
+  states: State[] | undefined;
+}
+```
+
+All four interfaces are exported from the package root:
+
+```ts
+import type { Country, State, City, LocationData } from '@brmorillo/global-locations';
+```
+
+## Conventions
+
+These rules hold across the whole API:
+
+- **One static service.** `Countries` is a static utility class — never instantiated.
+  The `GlobalLocations` facade re-exports it (`GlobalLocations.Countries === Countries`).
+- **Single object argument** for multi-parameter methods
+  (`getCountryBy({ property, value, selectStates })`); single-value lookups take a
+  positional argument (`getStatesByCountryId(countryId)`).
+- **`undefined` means "not found"** for lookups — they never throw. List methods
+  return `[]` for an empty or unknown scope.
+- **Read-only.** The bundled dataset is never mutated; `getCountryBy({ selectStates: true })`
+  returns a deep clone.
+- **Case-insensitive by default** for name/group searches (`searchCitiesByName`,
+  `getCountriesByContinent`, `getCountriesByEconomicGroup`).
 
 ## API
 
-### Countries
+Full reference with parameters, return values and examples lives in
+**[docs/countries/README.md](./docs/countries/README.md)**.
 
-- `findCountryByProperty(property, value)`: Finds a country by an arbitrary property
-- `getAllCountriesAndData()`: Returns all countries with complete data
-- `getAllCountries()`: Returns all countries without state data
-- `getCountryBy({ property, value, selectStates })`: Returns a specific country
-- `getAllStates()`: Returns all states from all countries
-- `getStatesByCountryId(countryId)`: Returns states of a specific country
-- `getStateByParams({ countryId, params })`: Searches for a specific state
-- `isStateInCountry({ countryId, stateId })`: Checks if a state belongs to a country
-- `getAllCities({ countryId })`: Returns all cities of a country
-- `getCitiesByStateId({ countryId, stateId })`: Returns cities of a specific state
-- `getCitiesByParams({ countryId, stateId, params })`: Searches for a specific city
-- `getCityById(cityId)`: Finds a city by its numeric id across all countries
-- `searchCitiesByName(name, caseSensitive?)`: Searches cities by (partial) name
-- `getCountriesByContinent(continent, includeStates?)`: Filters countries by continent
-- `getCountriesByEconomicGroup(group, includeStates?)`: Filters countries by economic group
+### Country
+| Method | Description |
+| --- | --- |
+| `findCountryByProperty(property, value)` | Find a country by an arbitrary property |
+| `getAllCountriesAndData()` | All countries with complete data (incl. states) |
+| `getAllCountries()` | All countries without state data |
+| `getCountryBy({ property, value, selectStates })` | A single country, optionally with states |
+| `getCountriesByContinent(continent, includeStates?)` | Countries on a continent (case-insensitive) |
+| `getCountriesByEconomicGroup(group, includeStates?)` | Countries in an economic group (case-insensitive) |
+
+### State
+| Method | Description |
+| --- | --- |
+| `getAllStates()` | Every state from every country, flattened |
+| `getStatesByCountryId(countryId)` | States of one country (`undefined` if unknown) |
+| `getStateByParams({ countryId, params })` | A single state, by an arbitrary property |
+| `isStateInCountry({ countryId, stateId })` | Whether a state belongs to a country |
+
+### City
+| Method | Description |
+| --- | --- |
+| `getAllCities({ countryId })` | Names of all cities in a country |
+| `getCitiesByStateId({ countryId, stateId })` | Names of all cities in a state |
+| `getCitiesByParams({ countryId, stateId, params })` | A single city name, by an arbitrary property |
+| `getCityById(cityId)` | A city by numeric id, across all countries |
+| `searchCitiesByName(name, caseSensitive?)` | Cities whose name contains `name` (partial match) |
+
+## Examples
+
+```typescript
+import { Countries } from '@brmorillo/global-locations';
+
+// Lightweight list (no states): great for dropdowns
+Countries.getAllCountries();                       // [{ id: 'BR', name: 'Brasil', states: undefined }, …]
+
+// Drill down from country -> state -> city
+const states = Countries.getStatesByCountryId('BR');
+const firstState = states[0];
+Countries.getCitiesByStateId({ countryId: 'BR', stateId: String(firstState.id) });
+
+// Find a single city by its id (searches every country)
+Countries.getCityById(3550308);                    // { id: 3550308, name: 'São Paulo', stateId: 35 }
+
+// Fuzzy-ish name search (case-insensitive by default)
+Countries.searchCitiesByName('paulo')              // partial match
+  .map((hit) => `${hit.city.name}, ${hit.country.name}`);
+
+// Group by continent or economic block, optionally including states
+Countries.getCountriesByContinent('south america', /* includeStates */ true);
+Countries.getCountriesByEconomicGroup('Mercosul');
+```
 
 ## Quality & testing
 
-- **Dual build**: ships CommonJS (`require`) and ESM (`import`) plus its own `.d.ts`.
+- **Dual build** — ships CommonJS (`require`) and ESM (`import`) plus its own `.d.ts`.
 - **TypeScript strict** end to end.
-- **92 tests** (unit + integration) on jest, **100% coverage** (statements,
-  branches, functions, lines).
-- **External consumer smoke test** validates the published artifact via both
-  `require` and `import` — see [CONTRIBUTING.md](./CONTRIBUTING.md#external-consumer-smoke-test-cjs--esm).
+- **92 tests** (unit + integration) on jest, **100% coverage** (statements, branches,
+  functions, lines), enforced by a CI coverage gate.
+- **External consumer smoke test** installs the packed tarball and exercises every
+  public method via both `require` and `import` — see
+  [CONTRIBUTING.md](./CONTRIBUTING.md#external-consumer-smoke-test-cjs--esm).
 
 ```bash
 bun install
@@ -79,15 +183,60 @@ bun run build         # CJS + ESM + d.ts
 
 ## Documentation
 
-- [docs/README.md](./docs/README.md) — documentation index and data shapes.
-- [docs/countries/README.md](./docs/countries/README.md) — full `Countries` reference: every method, parameters, return values and examples.
+- 📚 **[Module reference](./docs/README.md)** — documentation index and data shapes
+- 🗺️ **[Countries reference](./docs/countries/README.md)** — every method, parameters, returns and examples
+- 🤖 **[CLAUDE.md](./CLAUDE.md)** — architecture & conventions for contributors and AI assistants
+- 🤝 **[CONTRIBUTING.md](./CONTRIBUTING.md)** — how to contribute
+- 🔒 **[SECURITY.md](./SECURITY.md)** — vulnerability reporting & security policy
 
-## Contributing & security
+## Development
 
-- [CONTRIBUTING.md](./CONTRIBUTING.md) — setup, workflow, testing, release flow.
-- [SECURITY.md](./SECURITY.md) — supported versions and how to report a vulnerability.
-- [CLAUDE.md](./CLAUDE.md) — architecture, conventions and context for contributors/AI assistants.
+```bash
+bun install            # install dependencies (this project uses bun)
+bun run build          # typecheck + build (CJS + ESM + .d.ts)
+bun run type-check     # tsc --noEmit (strict)
+bun run test           # unit + integration tests
+bun run lint           # lint
+bun run format         # format with Prettier
+```
+
+## Contributing
+
+All contributions must follow these conventions:
+
+- **Commit messages** — [Conventional Commits](https://www.conventionalcommits.org/):
+  `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`. Breaking changes get a `!`
+  suffix (`feat!:`) and a `BREAKING CHANGE:` footer.
+- **Branch naming** — `feature/<short-name>`, `fix/<issue>`, `docs/<topic>`, `chore/<task>`.
+- **PR process** — open a PR against `main`; the CI pipeline (type-check → lint → test with
+  coverage gate → build → secret scan) must pass. The `pr-version` workflow automatically
+  commits the version bump (`chore(release): vX.Y.Z`) to your branch before merge.
+- **Public surface** — when you add/rename/remove a public method, update both
+  `docs/countries/README.md` and `tests/unit/public-surface.spec.ts` (it asserts the exact
+  method set).
+- **English only** — all identifiers, comments, doc strings and test descriptions in English.
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full guide, including the external
+consumer smoke test.
+
+## Dependency policy
+
+All runtime and development dependencies are pinned to **exact versions** (no `^`, `~`, or
+`latest`) for fully reproducible installs. The single runtime dependency is
+[`@brmorillo/utils`](https://www.npmjs.com/package/@brmorillo/utils).
+
+Because the package ships dual CJS + ESM, every runtime dependency must provide a CommonJS
+(`require`) build. Before bumping a runtime dependency major, verify it still ships one and
+re-run the consumer smoke test:
+
+```bash
+node -p "Object.keys(require('<package>/package.json').exports)"   # must include 'require'
+```
 
 ## License
 
 [LGPL-3.0-only](./LICENSE) © [Bruno Morillo](https://github.com/brmorillo)
+
+This library is free to use in any project (including commercial ones). You may not distribute
+it as a closed-source product or sell it as your own. Any modifications to the library itself
+must be released under the same license.

--- a/package.json
+++ b/package.json
@@ -81,7 +81,10 @@
     }
   },
   "files": [
-    "dist"
+    "dist/**/*.js",
+    "dist/**/*.mjs",
+    "dist/**/*.d.ts",
+    "dist/**/*.d.mts"
   ],
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brmorillo/global-locations",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Production-ready library for global location data — countries, states and cities behind one type-safe API. Dual CJS + ESM build.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
## Summary

Brings the README up to the same standard as `@brmorillo/utils`:

- Tagline + feature bullets, multi-package-manager install (bun/npm/pnpm/yarn), Node requirement
- Richer **Quick start** and a dedicated **Examples** section
- New **Data model** section (Country/State/City/LocationData shapes)
- **Conventions** section (single-object args, undefined-for-not-found, read-only, case-insensitive)
- Grouped **API** tables (Country / State / City) linking to `docs/countries`
- **Quality & testing**, **Documentation**, **Development**, **Contributing**, **Dependency policy** and **License** sections

Tailored to a data library (no crypto/services/typed-error sections) and keeps the latest-deps policy (does not adopt the utils 3-month lag rule).

## Type of change

- [x] Documentation (`docs:`)

## Test plan

- Docs-only change; no code touched. CI (type-check/lint/test/build/gitleaks) still runs.